### PR TITLE
1.2.1 - fraud-scam-detection-woocommerce (Campos padrões na página de configuração)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_NAME: fraud-scam-detection-woocommerce
   DIR_NAME: fraud-scam-detection-woocommerce
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.0"
+  DEPLOY_TAG: "1.2.1"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: fraud-and-scam-detection-for-woocommerce
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.0"
+  DEPLOY_TAG: "1.2.1"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.1 - 20/05/2026
+* Ajuste no estado padrão do checkbox na página de configurações.
+
 # 1.2.0 - 18/05/2026
 * Novo sistema de verificação de segurança com Cloudflare Turnstile.
 * Novo sistema de banimento de IPs.

--- a/Includes/templates/LknFsdwFraudAndScamDetectionForWoocommerceAdminSettingsLayout.php
+++ b/Includes/templates/LknFsdwFraudAndScamDetectionForWoocommerceAdminSettingsLayout.php
@@ -167,9 +167,8 @@ foreach ($form_fields as $key => $field) {
                                                         type="checkbox"
                                                         name="<?php echo esc_attr($field['id'] ? $field['id'] : $key); ?>"
                                                         id="<?php echo esc_attr($field['id'] ? $field['id'] : $key); ?>"
-                                                        value="yes"
                                                         class="admin-layout-checkbox"
-                                                        <?php checked(get_option($field['id'] ? $field['id'] : $key), 'yes'); ?>
+                                                        <?php checked(get_option($field['id'] ?: $key, $field['default'] ?? '') === 'yes'); ?>
                                                     />
                                                     <?php if (!empty($field['label'])): ?>
                                                         <span class="admin-layout-checkbox-label-text">
@@ -188,8 +187,7 @@ foreach ($form_fields as $key => $field) {
                                                         <input
                                                             type="radio"
                                                             name="<?php echo esc_attr($field['id'] ? $field['id'] : $key); ?>"
-                                                            value="<?php echo esc_attr($option_value); ?>"
-                                                            <?php checked(get_option($field['id'] ? $field['id'] : $key), $option_value); ?>
+                                                            <?php checked(get_option($field['id'] ?: $key, $field['default'] ?? '') === $option_value); ?>
                                                             id="<?php echo esc_attr($field['id'] ? $field['id'] : $key); ?>"
                                                             class="<?php echo !empty($field['class']) ? esc_attr($field['class']) : 'admin-layout-radio'; ?>"
                                                             <?php
@@ -358,9 +356,8 @@ foreach ($form_fields as $key => $field) {
                                                                 type="checkbox"
                                                                 name="<?php echo esc_attr($child_field['id'] ? $child_field['id'] : $child_key); ?>"
                                                                 id="<?php echo esc_attr($child_field['id'] ? $child_field['id'] : $child_key); ?>"
-                                                                value="yes"
                                                                 class="admin-layout-checkbox"
-                                                                <?php checked(get_option($child_field['id'] ? $child_field['id'] : $child_key), 'yes'); ?>
+                                                                <?php checked(get_option($child_field['id'] ?: $child_key, $child_field['default'] ?? '') === 'yes'); ?>
                                                             />
                                                             <?php if (!empty($child_field['label'])): ?>
                                                                 <span class="admin-layout-checkbox-label-text">
@@ -379,8 +376,8 @@ foreach ($form_fields as $key => $field) {
                                                                 <input
                                                                     type="radio"
                                                                     name="<?php echo esc_attr($child_field['id'] ? $child_field['id'] : $child_key); ?>"
-                                                                    value="<?php echo esc_attr($option_value); ?>"
-                                                                    <?php checked(get_option($child_field['id'] ? $child_field['id'] : $child_key), $option_value); ?>
+                                                                    <?php checked(get_option($child_field['id'] ?: $child_key, $child_field['default'] ?? '') === $option_value); ?>
+                                                                    id="<?php echo esc_attr($child_field['id'] ? $child_field['id'] : $child_key); ?>"
                                                                     class="<?php echo !empty($child_field['class']) ? esc_attr($child_field['class']) : 'admin-layout-radio'; ?>"
                                                                     <?php
                                                                     if (isset($child_field['custom_attributes']) && is_array($child_field['custom_attributes'])) {

--- a/Includes/templates/LknFsdwFraudAndScamDetectionForWoocommerceAdminSettingsLayout.php
+++ b/Includes/templates/LknFsdwFraudAndScamDetectionForWoocommerceAdminSettingsLayout.php
@@ -214,7 +214,7 @@ foreach ($form_fields as $key => $field) {
                                                 class="admin-layout-select"
                                             >
                                                 <?php foreach ($field['options'] as $option_key => $option_label): ?>
-                                                    <option value="<?php echo esc_attr($option_key); ?>" <?php selected(get_option($field['id'] ? $field['id'] : $key), $option_key); ?>>
+                                                    <option value="<?php echo esc_attr($option_key); ?>" <?php selected(get_option($field['id'] ?: $key, $field['default'] ?? '') === $option_key); ?>>
                                                         <?php echo esc_html($option_label); ?>
                                                     </option>
                                                 <?php endforeach; ?>
@@ -403,7 +403,7 @@ foreach ($form_fields as $key => $field) {
                                                         class="admin-layout-select"
                                                     >
                                                         <?php foreach ($child_field['options'] as $option_key => $option_label): ?>
-                                                            <option value="<?php echo esc_attr($option_key); ?>" <?php selected(get_option($child_field['id'] ? $child_field['id'] : $child_key), $option_key); ?>>
+                                                            <option value="<?php echo esc_attr($option_key); ?>" <?php selected(get_option($child_field['id'] ?: $child_key, $child_field['default'] ?? '') === $option_key); ?>>
                                                                 <?php echo esc_html($option_label); ?>
                                                             </option>
                                                         <?php endforeach; ?>

--- a/README.txt
+++ b/README.txt
@@ -118,6 +118,9 @@ When a customer attempts to complete a checkout, the plugin sends the Turnstile 
 
 
 == Changelog ==
+= 1.2.1 =
+* Fix default state of checkboxes on the settings page.
+
 = 1.2.0 =
 * New security verification system with Cloudflare Turnstile.
 * New IP banning system.
@@ -156,8 +159,12 @@ When a customer attempts to complete a checkout, the plugin sends the Turnstile 
 * Plugin launch with Google reCAPTCHA integration for WooCommerce checkout.
 
 == Upgrade Notice ==
+= 1.2.1 =
+* Fix default state of checkboxes on the settings page.
+
 = 1.2.0 =
 * New security verification system with Cloudflare Turnstile and IP banning feature.
+
 = 1.1.9/1.1.10 =
 * New banners according to country.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/
 Tags: woocommerce, antifraud, recaptcha, security, cloudflare
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 7.2
 Requires Plugins: woocommerce
 License: GPL-2.0+

--- a/fraud-scam-detection-woocommerce-file.php
+++ b/fraud-scam-detection-woocommerce-file.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('FRAUD_DETECTION_FOR_WOOCOMMERCE_VERSION')) {
-    define('FRAUD_DETECTION_FOR_WOOCOMMERCE_VERSION', '1.2.0');
+    define('FRAUD_DETECTION_FOR_WOOCOMMERCE_VERSION', '1.2.1');
 }
 
 if (! defined('FRAUD_DETECTION_FOR_WOOCOMMERCE_FILE')) {

--- a/fraud-scam-detection-woocommerce.php
+++ b/fraud-scam-detection-woocommerce.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Fraud and Scam Detection For WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/antifraude/
  * Description:       Performs verification and prevention of malicious payments.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/
  * License:           GPL-2.0+

--- a/uninstall.php
+++ b/uninstall.php
@@ -29,3 +29,38 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
+
+$lkn_fsdw_options = array(
+	'lknFraudDetectionForWoocommerceEnableRecaptcha',
+	'lknFraudDetectionForWoocommerceEnableIpLookup',
+	'lknFraudDetectionForWoocommerceEnableIpFilter',
+	'lknFraudDetectionForWoocommerceEnableIpBan',
+	'lknFraudDetectionForWoocommerceRecaptchaSelected',
+	'lknFraudDetectionForWoocommerceDebug',
+	'lknFraudDetectionForWoocommerceGoogleRecaptchaV3Key',
+	'lknFraudDetectionForWoocommerceGoogleRecaptchaV3Secret',
+	'lknFraudDetectionForWoocommerceGoogleRecaptchaV3Score',
+	'lknFraudDetectionForWoocommerceCloudflareTurnstileSiteKey',
+	'lknFraudDetectionForWoocommerceCloudflareTurnstileSecretKey',
+	'lknFraudDetectionForWoocommerceCloudflareTurnstileTheme',
+	'lknFraudDetectionForWoocommerceBannedIps',
+	'lknFraudDetectionForWoocommerceEnableIpCheck',
+);
+
+if ( is_multisite() ) {
+	$sites = get_sites( array( 'fields' => 'ids', 'number' => 0 ) );
+	foreach ( $sites as $site_id ) {
+		switch_to_blog( $site_id );
+		foreach ( $lkn_fsdw_options as $option ) {
+			delete_option( $option );
+		}
+		restore_current_blog();
+	}
+} else {
+	foreach ( $lkn_fsdw_options as $option ) {
+		delete_option( $option );
+	}
+}
+
+// Remove user meta for all users.
+delete_metadata( 'user', 0, 'lkn_fsdw_update_notice_dismissed', '', true );


### PR DESCRIPTION
# Detecção de Fraudes e Golpes para WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, fraude, golpe, segurança, detecção, cloudflare

Testado até: 6.9

Versão estável: 1.2.1

Licença: GPLv2 ou posterior

URI da Licença: https://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português (Brasil) / Inglês

Aprimore a segurança da sua loja WooCommerce com ferramentas avançadas de detecção de fraudes e golpes, incluindo verificação de imagens, reCAPTCHA e regras de validação personalizáveis.

## Descrição

O plugin Detecção de Fraudes e Golpes para WooCommerce oferece ferramentas robustas para proteger sua loja contra pedidos fraudulentos e golpes. A integração é feita de forma transparente com o WooCommerce e inclui:

- **Verificação de imagens** para pedidos suspeitos
- **Integração com reCAPTCHA** nos formulários de checkout
- **Regras de validação personalizáveis** para pedidos
- **Suporte a shortcode** para formulários personalizados
- **Registro detalhado** de eventos de validação

**Principais Recursos**

- Detecta e marca pedidos suspeitos com base em critérios configuráveis
- Integra Google reCAPTCHA para proteção contra bots
- Layouts de imagens personalizáveis na interface do plugin
- Compatível com o editor de blocos WooCommerce (Gutenberg)
- Registra todos os eventos de validação e detecção de fraude para auditoria e revisão

**Dependências**

Este plugin requer o WooCommerce instalado e ativado.

**Instruções de Uso**

1. No menu lateral do WordPress, procure por 'Detecção de Fraudes e Golpes'.
2. Vá em WooCommerce > Configurações > Detecção de Fraudes e Golpes para configurar as opções do plugin.
3. Ative e configure o reCAPTCHA, verificação de imagens e regras de validação conforme necessário.
4. Utilize o shortcode fornecido para adicionar formulários de detecção de fraude em páginas personalizadas, se desejar.
5. Salve as configurações.

Sua loja WooCommerce estará protegida com recursos avançados de detecção de fraudes e golpes.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá em Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin.
4. Clique em "Instalar Agora" e depois em "Ativar Plugin".
5. Certifique-se de que o WooCommerce também está ativado.

## CHANGELOG:

# 1.2.1 - 20/05/2026
* Ajuste no estado padrão do checkbox na página de configurações.